### PR TITLE
boost version hack fix.

### DIFF
--- a/style.py
+++ b/style.py
@@ -304,7 +304,7 @@ class StyleTransfer(object):
         null_fds = os.open(os.devnull, os.O_RDWR)
         out_orig = os.dup(2)
         os.dup2(null_fds, 2)
-        net = caffe.Net(model_file, pretrained_file, caffe.TEST)
+        net = caffe.Net(str(model_file), str(pretrained_file), caffe.TEST)
         os.dup2(out_orig, 2)
         os.close(null_fds)
 


### PR DESCRIPTION
As seen in [this caffe issue](https://github.com/BVLC/caffe/issues/3220), the construction of caffe.Net objects can fail with certain versions of boost and string encodings. I ran into the error message:

```
ArgumentError: Python argument types in
    Net.__init__(Net, unicode, unicode, int)
did not match C++ signature:
    __init__(boost::python::api::object, std::string, std::string, int) 
```
This error occurs when using the kaixhin/caffe docker image of caffe. The explicit call to str which this pull request adds gets this style transfer project working out of the box in this environment. I think this is significant because this is a docker image recommended in the caffe installation docs.