### PR TITLE
Make it compatible with python3

### DIFF
--- a/style.py
+++ b/style.py
@@ -437,9 +437,9 @@ class StyleTransfer(object):
         # compute data bounds
         data_min = -self.transformer.mean["data"][:,0,0]
         data_max = data_min + self.transformer.raw_scale["data"]
-        data_bounds = [(data_min[0], data_max[0])]*(img0.size/3) + \
-                      [(data_min[1], data_max[1])]*(img0.size/3) + \
-                      [(data_min[2], data_max[2])]*(img0.size/3)
+        data_bounds = [(data_min[0], data_max[0])] * int(img0.size / 3) + \
+                      [(data_min[1], data_max[1])] * int(img0.size / 3) + \
+                      [(data_min[2], data_max[2])] * int(img0.size / 3)
 
         # optimization params
         grad_method = "L-BFGS-B"


### PR DESCRIPTION
When data bounds calculating, the outcome of division in python3 is _float_, so it needs to be casted to _int_ before multiplying against the bounds.